### PR TITLE
Support `presentSide` option on `SPIndicator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ Burnt.toast({
 
   duration: 2         // duration in seconds
 
-  shouldDismissByDrag: true
+  shouldDismissByDrag: true,
+
+  from: 'bottom', // ios only, "top" or "bottom"
 })
 ```
 

--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -184,7 +184,7 @@ public class BurntModule: Module {
 
       view.dismissByDrag = options.shouldDismissByDrag
 
-      view.from = options.from;
+      view.presentSide = options.from;
 
       view.present(haptic: options.haptic.toSPIndicatorHaptic())
     }.runOnQueue(.main) 

--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -184,7 +184,7 @@ public class BurntModule: Module {
 
       view.dismissByDrag = options.shouldDismissByDrag
 
-      view.presentSide = options.from;
+      view.presentSide = options.from.toSPIndicatorPresentSide();
 
       view.present(haptic: options.haptic.toSPIndicatorHaptic())
     }.runOnQueue(.main) 

--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -114,6 +114,9 @@ struct ToastOptions: Record {
 
   @Field
   var haptic: ToastHaptic = .none
+
+  @Field
+  var from: ToastPresentSide = .top
 }
 
 enum ToastHaptic: String, EnumArgument {
@@ -150,6 +153,20 @@ enum ToastPreset: String, EnumArgument {
   }
 }
 
+enum ToastPresentSide: String, EnumArgument {
+  case top
+  case bottom
+
+  func toSPIndicatorPresentSide() -> SPIndicatorPresentSide {
+    switch self {
+    case .top:
+      return .top
+    case .bottom:
+      return .bottom
+    }
+  }
+}
+
 public class BurntModule: Module {
   public func definition() -> ModuleDefinition {
     Name("Burnt")
@@ -166,6 +183,8 @@ public class BurntModule: Module {
       }
 
       view.dismissByDrag = options.shouldDismissByDrag
+
+      view.from = options.from;
 
       view.present(haptic: options.haptic.toSPIndicatorHaptic())
     }.runOnQueue(.main) 

--- a/src/BurntModule.android.ts
+++ b/src/BurntModule.android.ts
@@ -10,11 +10,11 @@ export default {
       duration,
     });
   },
-  toastAsync({ title, duration = 5 }: ToastOptions) {
+  toastAsync({ title, duration = 5, from = 'bottom' }: ToastOptions) {
     ToastAndroid.showWithGravityAndOffset(
       title,
       duration * 1000,
-      ToastAndroid.BOTTOM,
+      from === 'bottom' ? ToastAndroid.BOTTOM : ToastAndroid.TOP,
       25,
       50
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,5 +54,5 @@ export type ToastOptions = {
    * Defaults to `true`.
    */
   shouldDismissByDrag?: boolean;
-  from: "top" | "bottom";
+  from?: "top" | "bottom";
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,5 +54,9 @@ export type ToastOptions = {
    * Defaults to `true`.
    */
   shouldDismissByDrag?: boolean;
+  /**
+   * Change the presentation side.
+   * @platform ios
+   */
   from?: "top" | "bottom";
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,4 +54,5 @@ export type ToastOptions = {
    * Defaults to `true`.
    */
   shouldDismissByDrag?: boolean;
+  from: "top" | "bottom";
 };


### PR DESCRIPTION
This PR adds support for the `presentSide` option on `SPIndicator`. 

With this you can show the toast at the bottom of the screen on iOS by adding `from: 'bottom'` when calling `Burnt.toast()` (this mimics the API from `SPIndicator`, but feel free to change the option name if something else is more clear).

I tried to get it working on Android to support showing the toast at the top, but it does not work like its described in the docs:

https://reactnative.dev/docs/toastandroid
```tsx
ToastAndroid.showWithGravityAndOffset(
  title,
  duration * 1000,
  from === 'bottom' ? ToastAndroid.BOTTOM : ToastAndroid.TOP, // does not work
  25,
  50
);
```

The JSDoc makes it clear that this is iOS only.