### PR TITLE
feat: supports custom and without icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also `Burnt.alert()` and `Burnt.dismissAllAlerts()`.
 - [x] Android support
 - [ ] Web support (could be cool to use Radix UI...but maybe I'll leave that
       part up to Zeego)
-- [ ] Custom iOS icons
+- [x] Custom iOS icons
 
 Chances are, I'll keep this lib to iOS & Android only, and then another library
 can consume it to build a broader API out on the JS side with Web support, such

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -64,8 +64,12 @@ export default function App() {
           Burnt.alert({
             title: "Verified account",
             preset: "custom",
-            iosIconName: "checkmark.seal",
-            iconColor: "#1D9BF0",
+            icon: {
+              ios: {
+                name: 'checkmark.seal',
+                color: '#1D9BF0'
+              }
+            }
           });
         }}
       >
@@ -120,8 +124,12 @@ export default function App() {
           Burnt.toast({
             title: "This is a large text and custom icon toast!!!",
             preset: "custom",
-            iosIconName: "sparkle",
-            iconColor: "#F7A51D",
+            icon: {
+              ios: {
+                name: 'sparkle',
+                color: '#F7A51D'
+              }
+            }
           });
         }}
       >

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -58,6 +58,21 @@ export default function App() {
       </Text>
 
       <View style={{ height: 16 }} />
+      <Text
+        style={[styles.text, styles.yellow]}
+        onPress={async () => {
+          Burnt.alert({
+            title: "Verified account",
+            preset: "custom",
+            iosIconName: "checkmark.seal",
+            iconColor: "#1D9BF0",
+          });
+        }}
+      >
+        Custom Icon Alert
+      </Text>
+
+      <View style={{ height: 16 }} />
 
       <Text
         style={[styles.text, styles.green]}
@@ -85,6 +100,32 @@ export default function App() {
         }}
       >
         Success Toast
+      </Text>
+      <View style={{ height: 16 }} />
+      <Text
+        style={[styles.text, styles.blue]}
+        onPress={async () => {
+          Burnt.toast({
+            title: "This is a large text and without icon toast!!!",
+            preset: "none",
+          });
+        }}
+      >
+        Without Icon Toast
+      </Text>
+      <View style={{ height: 16 }} />
+      <Text
+        style={[styles.text, styles.blue]}
+        onPress={async () => {
+          Burnt.toast({
+            title: "This is a large text and custom icon toast!!!",
+            preset: "custom",
+            iosIconName: "sparkle",
+            iconColor: "#F7A51D",
+          });
+        }}
+      >
+        Custom Icon Toast
       </Text>
     </>
   );

--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -137,7 +137,7 @@ struct ToastOptions: Record {
   var from: ToastPresentSide = .top
   
   @Field
-  var iosIconName: String? = nil
+  var iconName: String? = nil
   
   @Field
   var iconColor: UIColor = .systemBlue
@@ -176,7 +176,7 @@ enum ToastPreset: String, Enumerable {
     case .error:
       return .error
     case .custom:
-        return .custom(UIImage.init( systemName: options?.iosIconName ?? "swift")!.withTintColor(options?.iconColor ?? .systemBlue, renderingMode: .alwaysOriginal))
+        return .custom(UIImage.init( systemName: options?.iconName ?? "swift")!.withTintColor(options?.iconColor ?? .systemBlue, renderingMode: .alwaysOriginal))
     case .none:
       return .none
         

--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -20,7 +20,7 @@ enum AlertPreset: String, Enumerable {
     case .spinner:
       return .spinner
     case .custom:
-      return .custom(UIImage.init( systemName: options?.iosIconName ?? "swift")!.withTintColor(options?.iconColor ?? .systemBlue, renderingMode: .alwaysOriginal))
+      return .custom(UIImage.init( systemName: options?.iconName ?? "swift")!.withTintColor(options?.iconColor ?? .systemBlue, renderingMode: .alwaysOriginal))
         
     }
   }
@@ -75,7 +75,7 @@ struct AlertOptions: Record {
   var layout: AlertLayout?
   
   @Field
-  var iosIconName: String? = nil
+  var iconName: String? = nil
   
   @Field
   var iconColor: UIColor = .systemGray

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,23 @@
 // Import the native module. On web, it will be resolved to Burnt.web.ts
 // and on native platforms to Burnt.ts
+import { processColor } from "react-native";
 import BurntModule from "./BurntModule";
 import { AlertOptions, ToastOptions } from "./types";
 
-export function alert({
-  preset = "done",
-  duration = 5,
-  ...options
-}: AlertOptions) {
-  return BurntModule.alertAsync({ duration, preset, ...options });
+export function alert({ duration = 5, ...options }: AlertOptions) {
+  let iconColor;
+  if (options.preset === "custom") {
+    iconColor = options.iconColor ? processColor(options.iconColor) : null;
+  }
+  return BurntModule.alertAsync({ duration, ...options, iconColor });
 }
 
 export function toast({ duration = 5, ...options }: ToastOptions) {
-  return BurntModule.toastAsync({ duration, ...options });
+  let iconColor;
+  if (options.preset === "custom") {
+    iconColor = options.iconColor ? processColor(options.iconColor) : null;
+  }
+  return BurntModule.toastAsync({ duration, ...options, iconColor });
 }
 
 export function dismissAllAlerts() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,23 +3,34 @@
 import { processColor } from "react-native";
 import BurntModule from "./BurntModule";
 import { AlertOptions, ToastOptions } from "./types";
+import { Platform } from 'react-native'
 
 export function alert({ duration = 5, ...options }: AlertOptions) {
-  let iconColor;
+  let iconColor = null;
+  let iconName;
   if (options.preset === "custom") {
-    iconColor = options.iconColor ? processColor(options.iconColor) : null;
+    const icon = options.icon[Platform.OS]
+    if (icon) {
+      iconName = icon.name;
+      iconColor = icon.color && processColor(icon.color)
+    }
   }
-  return BurntModule.alertAsync({ duration, ...options, iconColor });
+  return BurntModule.alertAsync({ duration, ...options, iconColor, iconName })
 }
 
 export function toast({ duration = 5, ...options }: ToastOptions) {
   let iconColor;
+  let iconName;
   if (options.preset === "custom") {
-    iconColor = options.iconColor ? processColor(options.iconColor) : null;
+    const icon = options.icon[Platform.OS]
+    if (icon) {
+      iconName = icon.name;
+      iconColor = icon.color && processColor(icon.color)
+    }
   }
-  return BurntModule.toastAsync({ duration, ...options, iconColor });
+  return BurntModule.toastAsync({ duration, ...options, iconColor, iconName })
 }
 
 export function dismissAllAlerts() {
-  return BurntModule.dismissAllAlertsAsync();
+  return BurntModule.dismissAllAlertsAsync()
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export type BaseToastOptions = {
   /**
    * Defaults to `done`.
    */
-  preset?: "done" | "error" | "none"; // TODO custom option
+  preset?: "done" | "error" | "none";
   /**
    * Duration in seconds.
    */
@@ -101,11 +101,7 @@ export type CustomToastOptions = Omit<BaseToastOptions, "preset"> & {
   /**
    * Defaults to `done`.
    */
-  preset?: "custom"; // TODO custom option
-  /**
-   * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
-   * @platform ios
-   */
+  preset?: "custom";
   icon: Icon
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export type AlertOptions = {
   title: string;
-  message: string;
+  message?: string;
   /**
    * Defaults to `true`.
    */
@@ -8,7 +8,10 @@ export type AlertOptions = {
   layout?: Layout;
 } & (
   | {
-      preset: "heart" | "done" | "error";
+      /**
+       * Defaults to `done`.
+       */
+      preset?: "heart" | "done" | "error" | "none";
 
       /**
        * Duration in seconds.
@@ -40,6 +43,23 @@ export type AlertOptions = {
        */
       duration: number;
     }
+  | {
+      preset: "custom";
+      /**
+       * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
+       * @platform ios
+       */
+      iosIconName?: string;
+      /**
+       * Change the custom icon color, default is system blue.
+       * @platform ios
+       */
+      iconColor?: string;
+      /**
+       * Duration in seconds.
+       */
+      duration?: number;
+    }
 );
 
 type Layout = {
@@ -49,10 +69,13 @@ type Layout = {
   };
 };
 
-export type ToastOptions = {
+export type BaseToastOptions = {
   title: string;
-  message: string;
-  preset: "done" | "error"; // TODO custom option
+  message?: string;
+  /**
+   * Defaults to `done`.
+   */
+  preset?: "done" | "error" | "none"; // TODO custom option
   /**
    * Duration in seconds.
    */
@@ -69,3 +92,22 @@ export type ToastOptions = {
   from?: "top" | "bottom";
   layout?: Layout;
 };
+
+export type CustomToastOptions = Omit<BaseToastOptions, "preset"> & {
+  /**
+   * Defaults to `done`.
+   */
+  preset?: "custom"; // TODO custom option
+  /**
+   * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
+   * @platform ios
+   */
+  iosIconName?: string;
+  /**
+   * Change the custom icon color, default is system blue.
+   * @platform ios
+   */
+  iconColor?: string;
+};
+
+export type ToastOptions = BaseToastOptions | CustomToastOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,16 @@
+type Icon = {
+  ios?: {
+    /**
+     * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
+     */
+    name: string,
+    /**
+     * Change the custom icon color, default is system blue.
+     */
+    color?: string;
+  }
+}
+
 export type AlertOptions = {
   title: string;
   message?: string;
@@ -45,16 +58,7 @@ export type AlertOptions = {
     }
   | {
       preset: "custom";
-      /**
-       * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
-       * @platform ios
-       */
-      iosIconName?: string;
-      /**
-       * Change the custom icon color, default is system blue.
-       * @platform ios
-       */
-      iconColor?: string;
+      icon: Icon
       /**
        * Duration in seconds.
        */
@@ -102,12 +106,7 @@ export type CustomToastOptions = Omit<BaseToastOptions, "preset"> & {
    * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
    * @platform ios
    */
-  iosIconName?: string;
-  /**
-   * Change the custom icon color, default is system blue.
-   * @platform ios
-   */
-  iconColor?: string;
+  icon: Icon
 };
 
 export type ToastOptions = BaseToastOptions | CustomToastOptions;


### PR DESCRIPTION
# Why   

[burnt](https://github.com/nandorojo/burnt) has not supported some features below:  

1. large text, now only supported one line of text. if you pass some long text will be omitted.
2. custom ios icon, now only support `error` and `done` icon.
3. hide icons, sometimes we need to hide icons. 
4. some parameters are not required but the ts type is required.
 
so I made this PR to support them.  

# How  

update some ts type and improve the `BurntModule.swift` native module. 


# Test  

https://user-images.githubusercontent.com/37520667/222522792-f7b5d7d3-5f5b-4a51-913a-fbf1a2cb213d.mp4



