### PR TITLE
feat(new): supports custom and without icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ You can also `Burnt.alert()` and `Burnt.dismissAllAlerts()`.
 
 - [x] iOS support
 - [x] Android support
+- [x] Custom iOS icons
 - [ ] Web support (could be cool to use Radix UI...but maybe I'll leave that
       part up to Zeego)
-- [x] Custom iOS icons
 
 Chances are, I'll keep this lib to iOS & Android only, and then another library
 can consume it to build a broader API out on the JS side with Web support, such
@@ -132,7 +132,7 @@ _The API changed since recording this video. It now uses object syntax._
 Burnt.toast({
   title: 'Congrats!', // required
 
-  preset: 'done',     // or "error"
+  preset: 'done',     // or "error", "custom"
 
   message: '',        // optional
 
@@ -150,8 +150,13 @@ Burnt.toast({
       height: 24,
       width: 24,
     },
-
-    // TODO: custom SF Symbols...
+  icon: {
+    ios: {
+      // SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
+      name: "checkmark.seal",
+      color: "#1D9BF0",
+    },
+  },
   },
 })
 ```
@@ -171,7 +176,7 @@ export const alert = () => {
   Burnt.alert({
     title: "Congrats!", // required
 
-    preset: "done", // or "error", "heart"
+    preset: "done", // or "error", "heart", "custom"
 
     message: "", // optional
 
@@ -183,7 +188,13 @@ export const alert = () => {
         height: 24,
         width: 24,
       },
-      // TODO: custom SF Symbols...
+    },
+    icon: {
+      ios: {
+        // SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
+        name: "checkmark.seal",
+        color: "#1D9BF0",
+      },
     },
   });
 };

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You can also `Burnt.alert()` and `Burnt.dismissAllAlerts()`.
 - [x] Android support
 - [ ] Web support (could be cool to use Radix UI...but maybe I'll leave that
       part up to Zeego)
-- [ ] Custom iOS icons
+- [x] Custom iOS icons
 
 Chances are, I'll keep this lib to iOS & Android only, and then another library
 can consume it to build a broader API out on the JS side with Web support, such

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ _The API changed since recording this video. It now uses object syntax._
 Burnt.toast({
   title: 'Congrats!', // required
 
-  preset: 'done',     // or "error", "custom"
+  preset: 'done',     // or "error", "none", "custom"
 
   message: '',        // optional
 
@@ -149,7 +149,7 @@ Burnt.toast({
     iconSize: {
       height: 24,
       width: 24,
-    },
+  },
   icon: {
     ios: {
       // SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -58,6 +58,21 @@ export default function App() {
       </Text>
 
       <View style={{ height: 16 }} />
+      <Text
+        style={[styles.text, styles.yellow]}
+        onPress={async () => {
+          Burnt.alert({
+            title: "Verified account",
+            preset: "custom",
+            iosIconName: "checkmark.seal",
+            iconColor: "#1D9BF0",
+          });
+        }}
+      >
+        Custom Icon Alert
+      </Text>
+
+      <View style={{ height: 16 }} />
 
       <Text
         style={[styles.text, styles.green]}
@@ -85,6 +100,32 @@ export default function App() {
         }}
       >
         Success Toast
+      </Text>
+      <View style={{ height: 16 }} />
+      <Text
+        style={[styles.text, styles.blue]}
+        onPress={async () => {
+          Burnt.toast({
+            title: "This is a large text and without icon toast!!!",
+            preset: "none",
+          });
+        }}
+      >
+        Without Icon Toast
+      </Text>
+      <View style={{ height: 16 }} />
+      <Text
+        style={[styles.text, styles.blue]}
+        onPress={async () => {
+          Burnt.toast({
+            title: "This is a large text and custom icon toast!!!",
+            preset: "custom",
+            iosIconName: "sparkle",
+            iconColor: "#F7A51D",
+          });
+        }}
+      >
+        Custom Icon Toast
       </Text>
     </>
   );

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -64,8 +64,12 @@ export default function App() {
           Burnt.alert({
             title: "Verified account",
             preset: "custom",
-            iosIconName: "checkmark.seal",
-            iconColor: "#1D9BF0",
+            icon: {
+              ios: {
+                name: "checkmark.seal",
+                color: "#1D9BF0",
+              },
+            },
           });
         }}
       >
@@ -120,8 +124,12 @@ export default function App() {
           Burnt.toast({
             title: "This is a large text and custom icon toast!!!",
             preset: "custom",
-            iosIconName: "sparkle",
-            iconColor: "#F7A51D",
+            icon: {
+              ios: {
+                name: "sparkle",
+                color: "#F7A51D",
+              },
+            },
           });
         }}
       >

--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -186,7 +186,6 @@ enum ToastPreset: String, Enumerable {
         return .custom(UIImage.init( systemName: options?.icon?.name ?? "swift")!.withTintColor(options?.icon?.color ?? .systemBlue, renderingMode: .alwaysOriginal))
       case .none:
         return .none
-        
     }
   }
 }
@@ -210,15 +209,8 @@ public class BurntModule: Module {
     Name("Burnt")
     
     AsyncFunction("toastAsync") { (options: ToastOptions) -> Void in
-      let view : SPIndicatorView
-      if(options.preset == .none){
-        view = SPIndicatorView(title: options.title, message: options.message)
-      } else if(options.preset == .custom){
-        view = SPIndicatorView(title: options.title, message: options.message, preset: options.preset.toSPIndicatorPreset(options)!)
-      }
-      else{
-        view = SPIndicatorView(title: options.title, message: options.message, preset: options.preset.toSPIndicatorPreset(nil)!)
-      }
+      let preset = options.preset.toSPIndicatorPreset(options)
+      let view = (preset != nil) ? SPIndicatorView(title: options.title, message: options.message, preset: preset ?? .done):  SPIndicatorView(title: options.title, message: options.message)
       
       if let duration = options.duration {
         view.duration = duration
@@ -236,20 +228,10 @@ public class BurntModule: Module {
     }.runOnQueue(.main)
     
     AsyncFunction("alertAsync")  { (options: AlertOptions) -> Void in
-      let view : SPAlertView
-      if(options.preset == .custom){
-        view = SPAlertView(
-          title: options.title,
-          message: options.message,
-          preset: options.preset.toSPAlertIconPreset(options))
-      }
-      else{
-        view = SPAlertView(
-          title: options.title,
-          message: options.message,
-          preset: options.preset.toSPAlertIconPreset(nil))
-      }
-      
+      let view = SPAlertView(
+        title: options.title,
+        message: options.message,
+        preset: options.preset.toSPAlertIconPreset(options))
       
       if let duration = options.duration {
         view.duration = duration

--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -82,12 +82,6 @@ struct AlertOptions: Record {
 }
 struct Icon: Record {
   @Field
-  var width: Int?
-  
-  @Field
-  var height: Int?
-  
-  @Field
   var name: String? = nil
   
   @Field

--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -1,26 +1,26 @@
 import ExpoModulesCore
 import SPIndicator
 import SPAlert
- 
+
 enum AlertPreset: String, Enumerable {
   case done
   case error
   case heart
   case spinner
   case custom
-
+  
   func toSPAlertIconPreset(_ options: AlertOptions?) -> SPAlertIconPreset {
     switch self {
-    case .done:
-      return .done
-    case .error:
-      return .error
-    case .heart:
-      return .heart
-    case .spinner:
-      return .spinner
-    case .custom:
-      return .custom(UIImage.init( systemName: options?.iosIconName ?? "swift")!.withTintColor(options?.iconColor ?? .systemBlue, renderingMode: .alwaysOriginal))
+      case .done:
+        return .done
+      case .error:
+        return .error
+      case .heart:
+        return .heart
+      case .spinner:
+        return .spinner
+      case .custom:
+        return .custom(UIImage.init( systemName: options?.icon?.name ?? "swift")!.withTintColor(options?.icon?.color ?? .systemBlue, renderingMode: .alwaysOriginal))
         
     }
   }
@@ -32,17 +32,17 @@ enum AlertHaptic: String, Enumerable {
   case warning
   case error
   case none
-
+  
   func toSPAlertHaptic() -> SPAlertHaptic {
     switch self {
-    case .success:
-      return .success
-    case .warning:
-      return .warning
-    case .error:
-      return .error
-    case .none:
-      return .none
+      case .success:
+        return .success
+      case .warning:
+        return .warning
+      case .error:
+        return .error
+      case .none:
+        return .none
     }
   }
 }
@@ -58,33 +58,43 @@ struct AlertOptions: Record {
   
   @Field
   var message: String?
-
+  
   @Field
   var preset: AlertPreset = AlertPreset.done
-
+  
   @Field
   var duration: TimeInterval?
-
+  
   @Field
   var shouldDismissByTap: Bool = true
-
+  
   @Field
   var haptic: AlertHaptic = .none
-
+  
   @Field
   var layout: AlertLayout?
   
   @Field
-  var iosIconName: String? = nil
+  var icon: Icon? = nil
+}
+struct Icon: Record {
+  @Field
+  var width: Int?
   
   @Field
-  var iconColor: UIColor = .systemGray
+  var height: Int?
+  
+  @Field
+  var name: String? = nil
+  
+  @Field
+  var color: UIColor = .systemGray
 }
 
 struct IconSize: Record {
   @Field
   var width: Int
-
+  
   @Field
   var height: Int
 }
@@ -92,13 +102,13 @@ struct IconSize: Record {
 struct ToastMargins: Record {
   @Field
   var top: CGFloat?
-
+  
   @Field
   var left: CGFloat?
-
+  
   @Field
   var bottom: CGFloat?
-
+  
   @Field
   var right: CGFloat?
 }
@@ -106,7 +116,7 @@ struct ToastMargins: Record {
 struct ToastLayout: Record {
   @Field
   var iconSize: IconSize?
-
+  
   @Field
   var margins: ToastMargins?
 }
@@ -117,30 +127,27 @@ struct ToastOptions: Record {
   
   @Field
   var message: String?
-
+  
   @Field
   var preset: ToastPreset = ToastPreset.done
-
+  
   @Field
   var duration: TimeInterval?
-
+  
   @Field
   var layout: ToastLayout?
-
+  
   @Field
   var shouldDismissByDrag: Bool = true
-
+  
   @Field
   var haptic: ToastHaptic = .none
-
+  
   @Field
   var from: ToastPresentSide = .top
   
   @Field
-  var iosIconName: String? = nil
-  
-  @Field
-  var iconColor: UIColor = .systemBlue
+  var icon: Icon? = nil
 }
 
 enum ToastHaptic: String, Enumerable {
@@ -148,17 +155,17 @@ enum ToastHaptic: String, Enumerable {
   case warning
   case error
   case none
-
+  
   func toSPIndicatorHaptic() -> SPIndicatorHaptic {
     switch self {
-    case .success:
-      return .success
-    case .warning:
-      return .warning
-    case .error:
-      return .error
-    case .none:
-      return .none
+      case .success:
+        return .success
+      case .warning:
+        return .warning
+      case .error:
+        return .error
+      case .none:
+        return .none
     }
   }
 }
@@ -171,14 +178,14 @@ enum ToastPreset: String, Enumerable {
   
   func toSPIndicatorPreset(_ options: ToastOptions?) -> SPIndicatorIconPreset? {
     switch self {
-    case .done:
-      return .done
-    case .error:
-      return .error
-    case .custom:
-        return .custom(UIImage.init( systemName: options?.iosIconName ?? "swift")!.withTintColor(options?.iconColor ?? .systemBlue, renderingMode: .alwaysOriginal))
-    case .none:
-      return .none
+      case .done:
+        return .done
+      case .error:
+        return .error
+      case .custom:
+        return .custom(UIImage.init( systemName: options?.icon?.name ?? "swift")!.withTintColor(options?.icon?.color ?? .systemBlue, renderingMode: .alwaysOriginal))
+      case .none:
+        return .none
         
     }
   }
@@ -187,13 +194,13 @@ enum ToastPreset: String, Enumerable {
 enum ToastPresentSide: String, Enumerable {
   case top
   case bottom
-
+  
   func toSPIndicatorPresentSide() -> SPIndicatorPresentSide {
     switch self {
-    case .top:
-      return .top
-    case .bottom:
-      return .bottom
+      case .top:
+        return .top
+      case .bottom:
+        return .bottom
     }
   }
 }
@@ -201,7 +208,7 @@ enum ToastPresentSide: String, Enumerable {
 public class BurntModule: Module {
   public func definition() -> ModuleDefinition {
     Name("Burnt")
-
+    
     AsyncFunction("toastAsync") { (options: ToastOptions) -> Void in
       let view : SPIndicatorView
       if(options.preset == .none){
@@ -212,22 +219,22 @@ public class BurntModule: Module {
       else{
         view = SPIndicatorView(title: options.title, message: options.message, preset: options.preset.toSPIndicatorPreset(nil)!)
       }
-
+      
       if let duration = options.duration {
         view.duration = duration
       }
-
+      
       if let icon = options.layout?.iconSize {
         view.layout.iconSize = .init(width: icon.width, height: icon.height)
       }
       
       view.dismissByDrag = options.shouldDismissByDrag
-
+      
       view.presentSide = options.from.toSPIndicatorPresentSide();
-
+      
       view.present(haptic: options.haptic.toSPIndicatorHaptic())
-    }.runOnQueue(.main) 
-
+    }.runOnQueue(.main)
+    
     AsyncFunction("alertAsync")  { (options: AlertOptions) -> Void in
       let view : SPAlertView
       if(options.preset == .custom){
@@ -242,24 +249,24 @@ public class BurntModule: Module {
           message: options.message,
           preset: options.preset.toSPAlertIconPreset(nil))
       }
-
       
-        if let duration = options.duration {
-          view.duration = duration
-        }
-
-        view.dismissByTap = options.shouldDismissByTap
-
-        if let icon = options.layout?.iconSize {
-          view.layout.iconSize = .init(width: icon.width, height: icon.height)
-        }
-
-        view.present(
-          haptic: options.haptic.toSPAlertHaptic())
-     }.runOnQueue(.main) 
-
+      
+      if let duration = options.duration {
+        view.duration = duration
+      }
+      
+      view.dismissByTap = options.shouldDismissByTap
+      
+      if let icon = options.layout?.iconSize {
+        view.layout.iconSize = .init(width: icon.width, height: icon.height)
+      }
+      
+      view.present(
+        haptic: options.haptic.toSPAlertHaptic())
+    }.runOnQueue(.main)
+    
     AsyncFunction("dismissAllAlertsAsync") {
       return SPAlert.dismiss()
-    }.runOnQueue(.main) 
+    }.runOnQueue(.main)
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,31 @@
 // Import the native module. On web, it will be resolved to Burnt.web.ts
 // and on native platforms to Burnt.ts
-import { processColor } from "react-native";
+import { Platform, processColor } from "react-native";
 import BurntModule from "./BurntModule";
-import { AlertOptions, ToastOptions } from "./types";
+import { AlertOptions, IconParams, ToastOptions } from "./types";
+
+const getPlatfomIconProps = (params: IconParams) => {
+  if (Platform.OS === "ios") {
+    const color = params.ios?.color ? processColor(params.ios?.color) : null;
+    return { ...params.ios, color };
+  }
+  return {};
+};
 
 export function alert({ duration = 5, ...options }: AlertOptions) {
-  let iconColor;
+  let icon;
   if (options.preset === "custom") {
-    iconColor = options.iconColor ? processColor(options.iconColor) : null;
+    icon = getPlatfomIconProps(options.icon);
   }
-  return BurntModule.alertAsync({ duration, ...options, iconColor });
+  return BurntModule.alertAsync({ duration, ...options, icon });
 }
 
 export function toast({ duration = 5, ...options }: ToastOptions) {
-  let iconColor;
+  let icon;
   if (options.preset === "custom") {
-    iconColor = options.iconColor ? processColor(options.iconColor) : null;
+    icon = getPlatfomIconProps(options.icon);
   }
-  return BurntModule.toastAsync({ duration, ...options, iconColor });
+  return BurntModule.toastAsync({ duration, ...options, icon });
 }
 
 export function dismissAllAlerts() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,23 @@
 // Import the native module. On web, it will be resolved to Burnt.web.ts
 // and on native platforms to Burnt.ts
+import { processColor } from "react-native";
 import BurntModule from "./BurntModule";
 import { AlertOptions, ToastOptions } from "./types";
 
-export function alert({
-  preset = "done",
-  duration = 5,
-  ...options
-}: AlertOptions) {
-  return BurntModule.alertAsync({ duration, preset, ...options });
+export function alert({ duration = 5, ...options }: AlertOptions) {
+  let iconColor;
+  if (options.preset === "custom") {
+    iconColor = options.iconColor ? processColor(options.iconColor) : null;
+  }
+  return BurntModule.alertAsync({ duration, ...options, iconColor });
 }
 
 export function toast({ duration = 5, ...options }: ToastOptions) {
-  return BurntModule.toastAsync({ duration, ...options });
+  let iconColor;
+  if (options.preset === "custom") {
+    iconColor = options.iconColor ? processColor(options.iconColor) : null;
+  }
+  return BurntModule.toastAsync({ duration, ...options, iconColor });
 }
 
 export function dismissAllAlerts() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const getPlatfomIconProps = (params: IconParams) => {
     const color = params.ios?.color ? processColor(params.ios?.color) : null;
     return { ...params.ios, color };
   }
-  return {};
+  return null;
 };
 
 export function alert({ duration = 5, ...options }: AlertOptions) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,17 @@
+export type IconParams = {
+  ios: {
+    /**
+     * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
+     * @platform ios
+     */
+    name: string;
+    /**
+     * Change the custom icon color, default is system blue.
+     * @platform ios
+     */
+    color: string;
+  };
+};
 export type AlertOptions = {
   title: string;
   message?: string;
@@ -45,16 +59,8 @@ export type AlertOptions = {
     }
   | {
       preset: "custom";
-      /**
-       * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
-       * @platform ios
-       */
-      iosIconName?: string;
-      /**
-       * Change the custom icon color, default is system blue.
-       * @platform ios
-       */
-      iconColor?: string;
+
+      icon: IconParams;
       /**
        * Duration in seconds.
        */
@@ -98,16 +104,7 @@ export type CustomToastOptions = Omit<BaseToastOptions, "preset"> & {
    * Defaults to `done`.
    */
   preset?: "custom"; // TODO custom option
-  /**
-   * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
-   * @platform ios
-   */
-  iosIconName?: string;
-  /**
-   * Change the custom icon color, default is system blue.
-   * @platform ios
-   */
-  iconColor?: string;
+  icon: IconParams;
 };
 
 export type ToastOptions = BaseToastOptions | CustomToastOptions;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export type AlertOptions = {
   title: string;
-  message: string;
+  message?: string;
   /**
    * Defaults to `true`.
    */
@@ -8,7 +8,10 @@ export type AlertOptions = {
   layout?: Layout;
 } & (
   | {
-      preset: "heart" | "done" | "error";
+      /**
+       * Defaults to `done`.
+       */
+      preset?: "heart" | "done" | "error" | "none";
 
       /**
        * Duration in seconds.
@@ -40,6 +43,23 @@ export type AlertOptions = {
        */
       duration: number;
     }
+  | {
+      preset: "custom";
+      /**
+       * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
+       * @platform ios
+       */
+      iosIconName?: string;
+      /**
+       * Change the custom icon color, default is system blue.
+       * @platform ios
+       */
+      iconColor?: string;
+      /**
+       * Duration in seconds.
+       */
+      duration?: number;
+    }
 );
 
 type Layout = {
@@ -49,10 +69,13 @@ type Layout = {
   };
 };
 
-export type ToastOptions = {
+export type BaseToastOptions = {
   title: string;
-  message: string;
-  preset: "done" | "error"; // TODO custom option
+  message?: string;
+  /**
+   * Defaults to `done`.
+   */
+  preset?: "done" | "error" | "none"; // TODO custom option
   /**
    * Duration in seconds.
    */
@@ -69,3 +92,22 @@ export type ToastOptions = {
   from?: "top" | "bottom";
   layout?: Layout;
 };
+
+export type CustomToastOptions = Omit<BaseToastOptions, "preset"> & {
+  /**
+   * Defaults to `done`.
+   */
+  preset?: "custom"; // TODO custom option
+  /**
+   * The name of an iOS-only SF Symbol. For a full list, see https://developer.apple.com/sf-symbols/.
+   * @platform ios
+   */
+  iosIconName?: string;
+  /**
+   * Change the custom icon color, default is system blue.
+   * @platform ios
+   */
+  iconColor?: string;
+};
+
+export type ToastOptions = BaseToastOptions | CustomToastOptions;


### PR DESCRIPTION
# Why   

[burnt](https://github.com/nandorojo/burnt) has not supported some features below:  

1. large text, now only supported one line of text. if you pass some long text will be omitted.
2. custom ios icon, now only support `error` and `done` icon.
3. hide icons, sometimes we need to hide icons. 
4. some parameters are not required but the ts type is required.
 
so I made this PR to support them.  

# How  

update some ts type and improve the `BurntModule.swift` native module. 


# Test  

https://user-images.githubusercontent.com/37520667/222522792-f7b5d7d3-5f5b-4a51-913a-fbf1a2cb213d.mp4



