### PR TITLE
[docs] Use local Expo CLI in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ yarn add burnt
 Burnt likely requires Expo SDK 46+.
 
 ```sh
-expo install burnt expo-build-properties
+npx expo install burnt expo-build-properties
 ```
 
 Add the `expo-build-properties` plugin to your `app.json`/`app.config.js`,


### PR DESCRIPTION
I noticed most of the Expo-related commands use the local CLI (`npx expo ...`), except for the installation instructions. Updated them accordingly.