### PR TITLE
docs: remove ios only on the readme for .toast from property

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Burnt.toast({
 
   shouldDismissByDrag: true,
 
-  from: "bottom", // ios only, "top" or "bottom"
+  from: "bottom", // "top" or "bottom"
 
   // optionally customize layout
   layout: {


### PR DESCRIPTION
The code already support top / bottom on android too so the doc in readme is not up-to-date