### PR TITLE
Update Burnt.podspec

### DIFF
--- a/ios/Burnt.podspec
+++ b/ios/Burnt.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
   s.swift_version  = '5.4'
   s.source         = { git: 'https://github.com/nandorojo/burnt' }
   s.static_framework = true
-  s.dependency 'SPIndicator'
-  s.dependency 'SPAlert'
+  s.dependency 'SPIndicator', '~> 1.6'
+  s.dependency 'SPAlert', '~> 4.2'
 
   s.dependency 'ExpoModulesCore'
 


### PR DESCRIPTION
SPAlert is currently at version 5, causing the CI builds to fail. `SPAlertIconPreset` among other types are no longer available in version 5.

If you approve this can you kindly push a new version to NPM? Thanks 🙏 