### PR TITLE
Fix svg warnings

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -224,9 +224,9 @@ const WebIcon = () => {
       viewBox='0 0 24 24'
       fill='none'
       stroke='currentColor'
-      stroke-width='2'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
     >
       <path d='m14 12-8.5 8.5a2.12 2.12 0 1 1-3-3L11 9'></path>
       <path d='M15 13 9 7l4-4 6 6h3a8 8 0 0 1-7 7z'></path>

--- a/src/BurntModule.web.tsx
+++ b/src/BurntModule.web.tsx
@@ -69,9 +69,9 @@ const DoneIcon = () => (
     viewBox='0 0 24 24'
     fill='none'
     stroke='currentColor'
-    stroke-width='2'
-    stroke-linecap='round'
-    stroke-linejoin='round'
+    strokeWidth='2'
+    strokeLinecap='round'
+    strokeLinejoin='round'
     className='lucide lucide-check'
     data-burnt-icon='check'
   >
@@ -82,7 +82,7 @@ const DoneIcon = () => (
       stroke-dashoffset: -50;
       animation: burnt-draw-checkmark 400ms linear forwards;
     }
-  
+
     @keyframes burnt-draw-checkmark {
       100% {
         stroke-dashoffset: 0;
@@ -103,9 +103,9 @@ const XIcon = () => {
       viewBox='0 0 24 24'
       fill='none'
       stroke='currentColor'
-      stroke-width='2'
-      stroke-linecap='round'
-      stroke-linejoin='round'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
       className='lucide lucide-x'
       data-burnt-icon='x'
     >


### PR DESCRIPTION
I saw warnings in the Expo web view that looked like: 
`Invalid DOM property "stroke-width". Did you mean "strokeWidth"?`

To test, I copied over the build after running `yarn prepare` to my local Expo build and the warnings went away.