### PR TITLE
exposes icon fontweight from SF Symbol

### DIFF
--- a/ios/BurntModule.swift
+++ b/ios/BurntModule.swift
@@ -21,10 +21,19 @@ enum AlertPreset: String, Enumerable {
       case .spinner:
         return .spinner
       case .custom:
-        guard let image = UIImage.init( systemName: options?.icon?.name ?? "swift") else {
-          throw BurntError.invalidSystemName
+        let weight: UIImage.SymbolWeight
+        do {
+            weight = try toFontWeight(from: options?.icon?.fontWeight)
+        } catch {
+            throw BurntError.invalidIconWeight
         }
-        return .custom((image.withTintColor(options?.icon?.color ?? .systemBlue, renderingMode: .alwaysOriginal)))
+
+        let configuration = UIImage.SymbolConfiguration(weight: weight)
+         guard let image = UIImage(systemName: options?.icon?.name ?? "swift", withConfiguration: configuration) else {
+            throw BurntError.invalidSystemName
+        }
+
+        return .custom(image.withTintColor(options?.icon?.color ?? .systemBlue, renderingMode: .alwaysOriginal))
     }
   }
 }
@@ -86,6 +95,9 @@ struct Icon: Record {
   
   @Field
   var color: UIColor = .systemGray
+
+  @Field
+  var fontWeight: String = "regular"
 }
 
 struct IconSize: Record {
@@ -168,6 +180,7 @@ enum ToastHaptic: String, Enumerable {
 }
 enum BurntError: Error {
   case invalidSystemName
+  case invalidIconWeight
 }
 enum ToastPreset: String, Enumerable {
   case done
@@ -184,13 +197,23 @@ enum ToastPreset: String, Enumerable {
       case .none:
         return .none
       case .custom:
-        guard let image = UIImage.init( systemName: options?.icon?.name ?? "swift") else {
-          throw BurntError.invalidSystemName
+        let weight: UIImage.SymbolWeight
+        do {
+            weight = try toFontWeight(from: options?.icon?.fontWeight)
+        } catch {
+            throw BurntError.invalidIconWeight
         }
+
+        let configuration = UIImage.SymbolConfiguration(weight: weight)
+         guard let image = UIImage(systemName: options?.icon?.name ?? "swift", withConfiguration: configuration) else {
+            throw BurntError.invalidSystemName
+        }
+
         return .custom(image.withTintColor(options?.icon?.color ?? .systemBlue, renderingMode: .alwaysOriginal))
     }
   }
 }
+
 
 enum ToastPresentSide: String, Enumerable {
   case top
@@ -265,4 +288,19 @@ public class BurntModule: Module {
       return SPAlert.dismiss()
     }.runOnQueue(.main)
   }
+}
+
+func toFontWeight(from string: String?) -> UIImage.SymbolWeight {
+    switch string?.lowercased() {
+    case "ultralight": return .ultraLight
+    case "thin": return .thin
+    case "light": return .light
+    case "regular": return .regular
+    case "medium": return .medium
+    case "semibold": return .semibold
+    case "bold": return .bold
+    case "heavy": return .heavy
+    case "black": return .black
+    default: return .regular
+    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,20 @@ export type IconParams = {
      * @platform ios
      */
     color: string;
+    /**
+     * Change the custom icon font weight, default is system regular.
+     * @platform ios
+     */
+    fontWeight:
+      | "ultralight"
+      | "thin"
+      | "light"
+      | "regular"
+      | "medium"
+      | "semibold"
+      | "bold"
+      | "heavy"
+      | "black";
   };
   web?: JSX.Element;
 };


### PR DESCRIPTION
Exposes `fontWeight` 

bold checkmark:
![image](https://github.com/nandorojo/burnt/assets/1211905/85bd60e5-5eec-4b11-8f2b-ab54868bd4c2)

black checkmark:
![image](https://github.com/nandorojo/burnt/assets/1211905/f7c72522-7c60-4af2-8d52-d02dee70ecb5)


ultralight checkmark:
![image](https://github.com/nandorojo/burnt/assets/1211905/ded9d9e3-0a90-4ef3-aa52-5f5f6b2d333b)

