### PR TITLE
Upgrade `sonner` to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/nandorojo/burnt#readme",
   "dependencies": {
     "sf-symbols-typescript": "^1.0.0",
-    "sonner": "^0.3.5"
+    "sonner": "^2.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.0.25",

--- a/src/web.tsx
+++ b/src/web.tsx
@@ -8,7 +8,8 @@ export function getHasMountedWebToaster() {
   return hasMountedToaster;
 }
 
-export const Toaster: (typeof Sonner)["Toaster"] = (props) => {
+
+export const Toaster = (props: Sonner.ToasterProps) => {
   hasMountedToaster = true;
   useEffect(() => {
     hasMountedToaster = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4222,10 +4222,10 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sonner@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/sonner/-/sonner-0.3.5.tgz#5ef175732cb7b637c6460620ab01a0fba0e6a36b"
-  integrity sha512-yIwaQ4dftMvFApuruto2t7wGyyaPRpj5qYBWYJIz4Z7uGcVn0IfqI/hWN0JyJN4izNbZFuCYZISf3fOGnvSlNQ==
+sonner@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.1.tgz#f41774b2e0ee770152458a336570a4d577d03e6f"
+  integrity sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"


### PR DESCRIPTION
Hey! Sonner has improved a bit since the last release, so I wanted to bump the version. Maybe it should be marked as a peer dependency instead?

Also, I changed how the toaster is typed, just using `ToasterProps` now - typescript didn't like whatever was going on before.